### PR TITLE
Update to docker 17.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,18 @@ FROM jenkins:2.0
 USER root
 
 # install docker to have the CLI available
-RUN apt-get update && apt-get install -y apt-transport-https ca-certificates
-RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
-  echo "deb https://apt.dockerproject.org/repo debian-jessie main" > /etc/apt/sources.list.d/docker.list && \
-  apt-get update && \
-  apt-get install -y docker-engine
+ENV DOCKER_VERSION 17.12.0~ce-0~debian
+
+RUN apt-get update
+RUN apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add -
+RUN add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+   $(lsb_release -cs) \
+   stable"
+RUN apt-get update
+RUN apt-get install -y docker-ce=$DOCKER_VERSION
+
 
 # add jenkins user to docker group
 RUN usermod -a -G docker jenkins


### PR DESCRIPTION
Necessary for supporting multi-stage build.
Based on: https://docs.docker.com/engine/installation/linux/docker-ce/debian/